### PR TITLE
Make result_buffer_idces dtype integer.

### DIFF
--- a/augment/runner.py
+++ b/augment/runner.py
@@ -41,7 +41,7 @@ def run_experiment(seed):
     # Buffers for storing performance for all trial_types
     n_trial_types = len(task.trial_types)
     result_buffer = np.zeros((n_trial_types, stopping_crit_window))
-    result_buffer_idces = np.zeros(n_trial_types)
+    result_buffer_idces = np.zeros(n_trial_types, dtype=np.int)
     result_buffer_avgs = np.zeros((n_trial_types, trials))
 
     # Trial results (0: failure, 1: success)


### PR DESCRIPTION
I received an error with the below versions of Python and numpy when
result_buffer_idces contains float values.

Python 2.7.12
numpy==1.12.1